### PR TITLE
Fix broken HCL2 timestamp function by replacing it with a user variable

### DIFF
--- a/ops/ansible/playbook-appserver/README.md
+++ b/ops/ansible/playbook-appserver/README.md
@@ -74,13 +74,27 @@ issues and other breakage.
 
 ### Example command
 
-From within the `ops/ansible/playbook-appserver`, run the following command to kickoff a Packer
-build.
+This repo provides the [`packer-wrapper`](./packer-wrapper) script for executing Packer builds.
+This script makes life easier for the developer in a few ways. It:
+
+- Turns on the Packer logger
+- Validates the Packer build template
+- Passes the Ansible Vault password to the `root` environment
+
+From within the `ops/ansible/playbook-appserver`, first set your Ansible Vault Password as an
+environment variable to `ANSIBLE_VAULT_PASSWORD`:
 
 ```bash
-$ ANSIBLE_VAULT_PASSWORD='<vault-password>' sudo packer build ../../packer/build_webdavis-server.json
+$ export ANSIBLE_VAULT_PASSWORD='<vault-password>'
 ```
-This Packer build will spit out a `webdavis-server-<isotime>.img` file to the
+
+Then kickoff the Packer build by running the wrapper script:
+
+```bash
+$ ./packer-wrapper -var "tag=$(git rev-parse --short HEAD)" ../../packer/build_webdavis-server.pkr.hcl
+```
+
+This Packer build will spit out a `webdavis-server-<tag>.img` file in to the
 `ops/ansible/playbook-appserver` folder.
 
 ## Flashing the Image
@@ -93,5 +107,5 @@ modified image to your MicroSD card:
 $ pv webdavis-server-<isotime>.img | sudo dd bs=19M iflag=fullblock conv=fsync of=/dev/sdb
 ```
 
-> **Attention!** Adjust the `bs` opperand to the max write speed of your MicroSD card, USB 3.0
+> **Attention!** Adjust the `bs` operand to the max write speed of your MicroSD card, USB 3.0
 > device, etc.

--- a/ops/packer/build_webdavis-server.pkr.hcl
+++ b/ops/packer/build_webdavis-server.pkr.hcl
@@ -30,9 +30,9 @@ variable "ansible_vault_password" {
   default = env("ANSIBLE_VAULT_PASSWORD")
 }
 
-variable "isotime" {
+variable "tag" {
   type = string
-  default = formatdate("DD MMM YYYY hh:mm ZZZ", "2018-01-02T23:12:01Z")
+  default = ""
 }
 
 # "timestamp" template function replacement
@@ -68,7 +68,7 @@ source "arm" "webdavis-server" {
     start_sector = "532480"
     type = "83"
   }
-  image_path = "webdavis-server-${var.isotime}.img"
+  image_path = "webdavis-server-${var.tag}.img"
   image_size = "8G"
   image_type = "dos"
   qemu_binary_destination_path = "/usr/bin/qemu-arm-static"


### PR DESCRIPTION
This PR fixes the broken HCL2 timestamp by converting `iostime` to a `tag` passed in as a user variable. This has the advantage of being able to track Packer generated images using data passed in as Packer variables. For example:

```bash
$ ./packer-wrapper -var "tag=$(git rev-parse --short HEAD)" ../../packer/build_webdavis-server.pkr.hcl
```